### PR TITLE
added prefixed formatter + debug mode in which panics are not recovered

### DIFF
--- a/pakt.go
+++ b/pakt.go
@@ -463,12 +463,15 @@ func (s *Socket) read(buf []byte) (int, error) {
 }
 
 func (s *Socket) readLoop() {
-	// Catch panics.
-	defer func() {
-		if e := recover(); e != nil {
-			Log.Warningf("socket: read loop: catched panic: %v", e)
-		}
-	}()
+
+	if !Debug {
+		// Catch panics.
+		defer func() {
+			if e := recover(); e != nil {
+				Log.Warningf("socket: read loop: catched panic: %v", e)
+			}
+		}()
+	}
 
 	// Close the socket on exit.
 	defer s.Close()
@@ -584,12 +587,15 @@ func (s *Socket) readLoop() {
 }
 
 func (s *Socket) handleReceivedMessage(reqType byte, headerBuf, payloadBuf []byte) (err error) {
-	// Catch panics.
-	defer func() {
-		if e := recover(); e != nil {
-			err = fmt.Errorf("catched panic: %v", e)
-		}
-	}()
+
+	if !Debug {
+		// Catch panics.
+		defer func() {
+			if e := recover(); e != nil {
+				err = fmt.Errorf("catched panic: %v", e)
+			}
+		}()
+	}
 
 	// Reset the timeout, because data was successful read from the socket.
 	s.resetTimeout()

--- a/server.go
+++ b/server.go
@@ -211,12 +211,15 @@ func (s *Server) handleConnectionLoop() {
 }
 
 func (s *Server) handleConnection(conn net.Conn) {
-	// Catch panics.
-	defer func() {
-		if e := recover(); e != nil {
-			Log.Errorf("server catched panic: %v", e)
-		}
-	}()
+
+	if !Debug {
+		// Catch panics.
+		defer func() {
+			if e := recover(); e != nil {
+				Log.Errorf("server catched panic: %v", e)
+			}
+		}()
+	}
 
 	// Create a new socket.
 	socket := NewSocket(conn)

--- a/utils.go
+++ b/utils.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 
 	"github.com/Sirupsen/logrus"
+	prefixed "github.com/x-cray/logrus-prefixed-formatter"
 )
 
 const (
@@ -35,6 +36,10 @@ var (
 	// Log is the public logrus value used internally.
 	Log *logrus.Logger
 
+	// Debug mode does not recover from panics
+	// this allows the developer to see the stacktrace when a panic occurs
+	Debug bool
+
 	endian binary.ByteOrder = binary.BigEndian
 
 	errInvalidByteLen = errors.New("invalid byte length")
@@ -43,6 +48,7 @@ var (
 func init() {
 	// Create a new logger instance.
 	Log = logrus.New()
+	Log.Formatter = new(prefixed.TextFormatter)
 }
 
 func bytesToUint16(data []byte) (v uint16, err error) {


### PR DESCRIPTION
The Debug mode can be set using the global Debug var.
This disables recovering panics which is very useful for debugging,
because it allows seeing the panic stackstrace.

The prefixed formatter allows adding prefixes to log messages, which is helpful for debugging.
Also it has a very nice output.